### PR TITLE
fix: Missing errors in change password form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -43,7 +43,6 @@ class CrispyChangePasswordForm(ChangePasswordForm):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_method = "post"
-        self.helper.form_action = reverse("account_set_password")
         self.helper.form_show_errors = True
         self.helper.error_text_inline = True
         self.helper.help_text_inline = False


### PR DESCRIPTION
- Delete "self.helper.form_action = reverse("account_set_password")" in CruspyChangePasswordForm and fix missing errors in change password form.